### PR TITLE
Add compact block statistics to Debug window UI

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -113,6 +113,9 @@ void ClientModel::updateTimer2()
     thindata.FillThinBlockQuickStats(thinStats);
     Q_EMIT thinBlockPropagationStatsChanged(thinStats);
 
+    compactdata.FillCompactBlockQuickStats(compactStats);
+    Q_EMIT compactBlockPropagationStatsChanged(compactStats);
+
     graphenedata.FillGrapheneQuickStats(grapheneStats);
     Q_EMIT grapheneBlockPropagationStatsChanged(grapheneStats);
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_QT_CLIENTMODEL_H
 #define BITCOIN_QT_CLIENTMODEL_H
 
+#include "blockrelay/compactblock.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 
@@ -102,6 +103,7 @@ private:
     BanTableModel *banTableModel;
 
     ThinBlockQuickStats thinStats;
+    CompactBlockQuickStats compactStats;
     GrapheneQuickStats grapheneStats;
 
     QTimer *pollTimer1;
@@ -120,6 +122,7 @@ Q_SIGNALS:
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
     void transactionsPerSecondChanged(double tansactionsPerSecond); // BU:
     void thinBlockPropagationStatsChanged(const ThinBlockQuickStats &thin);
+    void compactBlockPropagationStatsChanged(const CompactBlockQuickStats &compact);
     void grapheneBlockPropagationStatsChanged(const GrapheneQuickStats &graphene);
 
     //! Fired when a message should be reported to the user

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -143,20 +143,34 @@
         </widget>
        </item>
        <item row="21" column="0">
+        <widget class="QLabel" name="labelCompactTotals">
+         <property name="text">
+          <string>Compact (Totals)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="labelCompact24hAverages">
+         <property name="text">
+          <string>Compact (24-Hour Averages)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="0">
         <widget class="QLabel" name="labelGrapheneTotals">
          <property name="text">
           <string>Graphene (Totals)</string>
          </property>
         </widget>
        </item>
-       <item row="22" column="0">
+       <item row="24" column="0">
         <widget class="QLabel" name="labelGraphene24hAverages">
          <property name="text">
           <string>Graphene (24-Hour Averages)</string>
          </property>
         </widget>
        </item>
-       <item row="23" column="2">
+       <item row="25" column="2">
         <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
          <property name="spacing">
           <number>3</number>
@@ -196,7 +210,7 @@
          </item>
         </layout>
        </item>
-       <item row="23" column="0" colspan="2">
+       <item row="25" column="0" colspan="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -209,7 +223,7 @@
          </property>
         </spacer>
        </item>
-       <item row="22" column="1" colspan="2">
+       <item row="24" column="1" colspan="2">
         <widget class="QLabel" name="blocksGraphene24hAverages">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -225,8 +239,40 @@
          </property>
         </widget>
        </item>
-       <item row="21" column="1" colspan="2">
+       <item row="23" column="1" colspan="2">
         <widget class="QLabel" name="blocksGrapheneTotals">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1" colspan="2">
+        <widget class="QLabel" name="blocksCompact24hAverages">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1" colspan="2">
+        <widget class="QLabel" name="blocksCompactTotals">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -397,6 +397,8 @@ void RPCConsole::setClientModel(ClientModel *model)
         connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
         connect(model, SIGNAL(thinBlockPropagationStatsChanged(const ThinBlockQuickStats &)), this,
             SLOT(setThinBlockPropagationStats(const ThinBlockQuickStats &)));
+        connect(model, SIGNAL(compactBlockPropagationStatsChanged(const CompactBlockQuickStats &)), this,
+            SLOT(setCompactBlockPropagationStats(const CompactBlockQuickStats &)));
         connect(model, SIGNAL(grapheneBlockPropagationStatsChanged(const GrapheneQuickStats &)), this,
             SLOT(setGrapheneBlockPropagationStats(const GrapheneQuickStats &)));
 
@@ -689,6 +691,35 @@ void RPCConsole::setThinBlockPropagationStats(const ThinBlockQuickStats &thin)
     text += QString::number(thin.fLast24hRerequestTxPercent, 'f', 1) + "%)";
 
     ui->blocksXThin24hAverages->setText(text);
+}
+
+void RPCConsole::setCompactBlockPropagationStats(const CompactBlockQuickStats &compact)
+{
+    if (!IsCompactBlocksEnabled())
+    {
+        ui->blocksCompactTotals->setText(tr("Disabled"));
+        ui->blocksCompact24hAverages->setText(tr("Disabled"));
+        return;
+    }
+
+    // Total: n (Sent: i / Received: r) saved bw
+    QString text = QString::number(compact.nTotalOutbound + compact.nTotalInbound) + " (Sent: ";
+    text += QString::number(compact.nTotalOutbound) + " / Received: ";
+    text += QString::number(compact.nTotalInbound) + ") saved ";
+    text += QString::fromStdString(formatInfoUnit(compact.nTotalBandwidthSavings));
+
+    ui->blocksCompactTotals->setText(text);
+
+    // 24-hour Average: n (Sent: i / Received: r), Compression (i% / r%), ReRequests f (f%)
+    text = QString::number(compact.nLast24hOutbound + compact.nLast24hInbound) + " (Sent: ";
+    text += QString::number(compact.nLast24hOutbound) + " / Received: ";
+    text += QString::number(compact.nLast24hInbound) + "), Compression (";
+    text += QString::number(compact.fLast24hOutboundCompression, 'f', 1) + "% / ";
+    text += QString::number(compact.fLast24hInboundCompression, 'f', 1) + "%), ReRequests ";
+    text += QString::number(compact.nLast24hRerequestTx) + " (";
+    text += QString::number(compact.fLast24hRerequestTxPercent, 'f', 1) + "%)";
+
+    ui->blocksCompact24hAverages->setText(text);
 }
 
 void RPCConsole::setGrapheneBlockPropagationStats(const GrapheneQuickStats &graphene)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -105,6 +105,8 @@ public Q_SLOTS:
     /** Set block propagation statistics in the UI */
     void setThinBlockPropagationStats(const ThinBlockQuickStats &thin);
     /** Set block propagation statistics in the UI */
+    void setCompactBlockPropagationStats(const CompactBlockQuickStats &compact);
+    /** Set block propagation statistics in the UI */
     void setGrapheneBlockPropagationStats(const GrapheneQuickStats &graphene);
     /** Go forward or back in history */
     void browseHistory(int offset);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -550,6 +550,10 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
             "  \"relayfee\": x.xxxxxxxx,              (numeric) minimum relay fee for non-free transactions in " +
             CURRENCY_UNIT +
             "/kB\n"
+            "  \"minlimitertxfee\": x.xxxx,           (numeric) fee (in satoshi/byte) below which transactions are "
+            "considered free and subject to limitfreerelay\n"
+            "  \"maxlimitertxfee\": x.xxxx,           (numeric) fee (in satoshi/byte) above which transactions are "
+            "always relayed\n"
             "  \"localaddresses\": [                  (array) list of local addresses\n"
             "    {\n"
             "      \"address\": \"xxxx\",               (string) network address\n"
@@ -559,6 +563,7 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
             "  ,...\n"
             "  ]\n"
             "  \"thinblockstats\": \"...\"              (string) thin block related statistics \n"
+            "  \"compactblockstats\": \"...\"           (string) compact block related statistics \n"
             "  \"grapheneblockstats\": \"...\"          (string) graphene block related statistics \n"
             "  \"warnings\": \"...\"                    (string) any network warnings (such as alert messages) \n"
             "}\n"
@@ -593,8 +598,8 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
     }
     obj.pushKV("localaddresses", localAddresses);
     obj.pushKV("thinblockstats", GetThinBlockStats());
-    obj.pushKV("grapheneblockstats", GetGrapheneStats());
     obj.pushKV("compactblockstats", GetCompactBlockStats());
+    obj.pushKV("grapheneblockstats", GetGrapheneStats());
     obj.pushKV("warnings", GetWarnings("statusbar"));
     return obj;
 }


### PR DESCRIPTION
Simply adds the block propagation statistics to the Debug window UI, the same as the XThin and Graphene statistics.

This is based off of what is already being recorded for the compact block statistics as that work was already implemented as part of the parent PR.

NOTE: The UI matches the RPC call, but I think there is something wrong in the statistics collection now.  I've had a build up and running for only ~2 hours, but I'm now seeing a mismatch in the number of total (all time) send/receive blocks of each type and the 24-hour statistics.  These should be identical for the first 24-hours for each propagation method, however the 24-hour totals are lower than the overall totals.
![image](https://user-images.githubusercontent.com/6402604/52033117-cf96de00-24f1-11e9-90eb-06f2c5a47f9b.png)

Not sure when this issue was introduced, but am looking into it.  I'll try looking at a build without the compact blocks PR as well to see if it's localized to this PR.